### PR TITLE
テスト項目確認修正

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,12 +1,12 @@
 class Admin::OrdersController < ApplicationController
-  
+
   def index
-     @orders = Order.all.page(params[:page])
+     @orders = Order.all.order(id: "DESC").page(params[:page]).per(10)
   end
-  
+
   def show
     @order = Order.find(params[:id])
-   
+
   end
 
   def update
@@ -20,9 +20,9 @@ class Admin::OrdersController < ApplicationController
       render :show
     end
   end
-  
+
   private
-  
+
   def order_params
     params.require(:order).permit(:order_status)
   end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -3,6 +3,10 @@
 class Admin::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  def after_sign_in_path_for(resource)
+    admin_orders_path
+  end
+
   def after_sign_out_path_for(resource)
     new_admin_session_path
   end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -30,7 +30,7 @@ class Public::CustomersController < ApplicationController
   private
 
   def customer_params
-    params.require(:customer).permit(:last_name, :first_name, :kana_last_name, :kana_first_name, :postal_code, :phone_number, :address, :is_deleted)
+    params.require(:customer).permit(:last_name, :first_name, :kana_last_name, :kana_first_name, :postal_code, :phone_number, :address, :email, :is_deleted)
   end
 
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -4,8 +4,12 @@ class Public::OrdersController < ApplicationController
 
   def new
     @order = Order.new
-    @customer = Customer.find(current_customer.id)
-    @shipping_addresses = current_customer.shipping_addresses.all
+    @address = ShippingAddress.new
+
+    # 以下必要？
+    # @customer = Customer.find(current_customer.id)
+    # @shipping_addresses = current_customer.shipping_addresses.all
+
   end
 
   def confirm
@@ -19,7 +23,7 @@ class Public::OrdersController < ApplicationController
           @order = Order.new
           @order.postal_code = current_customer.postal_code
           @order.shipping_address = current_customer.address
-          @order.shipping_name = current_customer.first_name + current_customer.last_name
+          @order.shipping_name = current_customer.last_name + current_customer.first_name
           @order.payment_method = params[:order][:payment_method]
 
     # 登録済み配送先の場合
@@ -38,11 +42,11 @@ class Public::OrdersController < ApplicationController
 
     #新しいお届け先の場合
 
-    else
+    else params[:order][:address_number] == "2"
       @order = Order.new
       @order.postal_code = params[:order][:postal_code]
-      @order.shipping_address = params[:order][:address]
-      @order.shipping_name = params[:order][:name]
+      @order.shipping_address = params[:order][:shipping_address]
+      @order.shipping_name = params[:order][:shipping_name]
       @order.payment_method = params[:order][:payment_method]
     end
   end
@@ -65,7 +69,7 @@ class Public::OrdersController < ApplicationController
      order_item.order_id = @order.id
      order_item.save
    end
-  
+
 
    redirect_to complete_orders_path
 

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -30,7 +30,7 @@
                                 <td class="text-right"><%= link_to "編集する", edit_admin_genre_path(genre), class: "btn btn-success" %></td>
                             </tr>
                         <% end %>
-                        
+
                     </tbody>
                 </table>
             </div>

--- a/app/views/public/cart_items/all_destroy.html.erb
+++ b/app/views/public/cart_items/all_destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#all_destroy</h1>
-<p>Find me in app/views/public/cart_items/all_destroy.html.erb</p>

--- a/app/views/public/cart_items/create.html.erb
+++ b/app/views/public/cart_items/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#create</h1>
-<p>Find me in app/views/public/cart_items/create.html.erb</p>

--- a/app/views/public/cart_items/destroy.html.erb
+++ b/app/views/public/cart_items/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#destroy</h1>
-<p>Find me in app/views/public/cart_items/destroy.html.erb</p>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -3,67 +3,81 @@
     <div class="col-4 mt-5 mb-5">
       <h3>ショッピングカート</h3>
     </div>
-    <div class="col-4 mt-5 mb-5">
-      <%= link_to "カートを空にする", cart_item_cart_items_all_destroy_path(current_customer.id), method: :delete, class: 'btn btn-danger btn-sm' %>
-    </div>
+    <% if  @cart_items.exists? %>
+      <div class="col-4 mt-5 mb-5">
+        <%= link_to "カートを空にする", cart_item_cart_items_all_destroy_path(current_customer.id), method: :delete, class: 'btn btn-danger btn-sm' %>
+      </div>
+    <% end %>
   </div>
 
-  <div class="row justify-content-center">
+  <% if  @cart_items.exists? %>
 
-    <table class="table">
-      <thead>
-        <tr>
-          <th>商品名</th>
-          <th>単価(税込)</th>
-          <th>数量</th>
-          <th>小計</th>
-          <th></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @cart_items.each do |cart_item| %>
-          <tr>
-            <td>
-              <%= cart_item.item.name %>
-            </td>
-            <td>
-              <%= cart_item.item.add_tax_price %>
-            </td>
-            <td>
-              <%= form_with model: cart_item, url: cart_item_path(cart_item), method: :patch do |f| %>
-                <%= f.select :quantity, *[1..10], {selected: cart_item.quantity.to_i} %>
-                <%= f.submit "更新", class: 'btn btn-success btn-sm' %>
-              <% end %>
-            </td>
-            <td>
-              <%= cart_item.subtotal %>
-            </td>
-            <td>
-              <%= link_to "削除する", cart_item_path(cart_item.id), method: :delete, class: 'btn btn-danger btn-sm' %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-  <div class="row justify-content-center">
-    <div class="col-4">
-      <%= link_to "買い物を続ける", root_path, class: 'btn btn-primary btn-sm' %>
-    </div>
-    <div class="col4">
+    <div class="row justify-content-center">
       <table class="table">
-        <tr>
-          <th>合計金額</th>
-          <td><%= @total.round.to_s(:delimited)%></td>
-        </tr>
+        <thead>
+          <tr>
+            <th>商品名</th>
+            <th>単価(税込)</th>
+            <th>数量</th>
+            <th>小計</th>
+            <th></th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @cart_items.each do |cart_item| %>
+            <tr>
+              <td>
+                <%= cart_item.item.name %>
+              </td>
+              <td>
+                <%= cart_item.item.add_tax_price %>
+              </td>
+              <td>
+                <%= form_with model: cart_item, url: cart_item_path(cart_item), method: :patch do |f| %>
+                  <%= f.select :quantity, *[1..10], {selected: cart_item.quantity.to_i} %>
+                  <%= f.submit "更新", class: 'btn btn-success btn-sm' %>
+                <% end %>
+              </td>
+              <td>
+                <%= cart_item.subtotal %>
+              </td>
+              <td>
+                <%= link_to "削除する", cart_item_path(cart_item.id), method: :delete, class: 'btn btn-danger btn-sm' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
       </table>
     </div>
-  </div>
-  <div class="row justify-content-center">
-    <div class="col-3">
-      <p class="text-center"><%= link_to "情報入力に進む", new_order_path, class: 'btn btn-success' %></p>
+
+    <div class="row justify-content-center">
+      <div class="col-4">
+        <%= link_to "買い物を続ける", root_path, class: 'btn btn-primary btn-sm' %>
+      </div>
+      <div class="col4">
+        <table class="table">
+          <tr>
+            <th>合計金額</th>
+            <td><%= @total.round.to_s(:delimited)%></td>
+          </tr>
+        </table>
+      </div>
     </div>
-  </div>
+    <div class="row justify-content-center">
+      <div class="col-3">
+        <p class="text-center"><%= link_to "情報入力に進む", new_order_path, class: 'btn btn-success' %></p>
+      </div>
+    </div>
+
+    <!--カートに商品が入っていなかった時-->
+    <% else %>
+      <div class="row justify-content-center flex-direction-column">
+        <div class="col-5">
+          <p class="h4 text-secondary">現在カートに商品は入っていません。</p>
+          <%= link_to "商品一覧へ", items_path, class: 'btn btn-outline-info mt-5' %>
+        </div>
+      </div>
+    <% end %>
 
 </div>

--- a/app/views/public/cart_items/update.html.erb
+++ b/app/views/public/cart_items/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::CartItems#update</h1>
-<p>Find me in app/views/public/cart_items/update.html.erb</p>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -6,44 +6,42 @@
   </div>
 
     <%= form_with model: @customer, url: information_path, method: :patch do |f| %>
-      <!--%= render "public/shared/error_messages", resource: resource %>-->
 
-        <div class="field">
-          <%= f.label :"名前" %>
-          <%= f.text_field :last_name %>
-          <%= f.text_field :first_name %>
-        </div>
+      <div class="field">
+        <%= f.label :名前 %>
+        <%= f.text_field :last_name %>
+        <%= f.text_field :first_name %>
+      </div>
 
-        <div class="field">
-          <%= f.label :"フリガナ" %>
-          <%= f.text_field :kana_last_name %>
-          <%= f.text_field :kana_first_name %>
-        </div>
+      <div class="field">
+        <%= f.label :フリガナ %>
+        <%= f.text_field :kana_last_name %>
+        <%= f.text_field :kana_first_name %>
+      </div>
 
-        <div class="field">
-          <%= f.label :郵便番号 %>
-          <%= f.text_field :postal_code %>
-        </div>
+      <div class="field">
+        <%= f.label :郵便番号 %>
+        <%= f.text_field :postal_code %>
+      </div>
 
-        <div class="field">
-          <%= f.label :"住所" %>
-          <%= f.text_field :address %>
-        </div>
+      <div class="field">
+        <%= f.label :住所 %>
+        <%= f.text_field :address %>
+      </div>
 
-        <div class="field">
-          <%= f.label :"電話番号" %>
-          <%= f.text_field :phone_number %>
-        </div>
+      <div class="field">
+        <%= f.label :電話番号 %>
+        <%= f.text_field :phone_number %>
+      </div>
 
-        <div class="field">
-          <%= f.label :メールアドレス %>
-          <%= f.text_field :email %>
-        </div>
+      <div class="field">
+        <%= f.label :メールアドレス %>
+        <%= f.text_field :email %>
+      </div>
 
-        <div class="actions">
-          <%= f.submit "編集内容を保存", class: "btn btn-success btn-sm" %>
-        </div>
-
+      <div class="actions">
+        <%= f.submit "編集内容を保存", class: "btn btn-success btn-sm" %>
+      </div>
     <% end %>
 
     <%= link_to "退会する", unsubscribe_path(@customer.id), class: 'btn btn-danger btn-sm mt-2' %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -23,8 +23,10 @@
         <p>(全<%= @items.count %>件)</p>
         <div class="col-md-9 d-flex flex-wrap">
           <% @items.each do |item| %>
-            <%= image_tag item.item_image, :size => '100x100' %><br>
-            <%= item.name %></br>
+            <%= link_to item_path(item.id) do %>
+              <%= image_tag item.item_image, :size => '100x100' %><br>
+              <%= item.name %>
+            <% end %>
             ￥<%= item.add_tax_price.to_s(:dalimited) %>
           <% end %>
         </div>

--- a/app/views/public/orders/create.html.erb
+++ b/app/views/public/orders/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::Orders#create</h1>
-<p>Find me in app/views/public/orders/create.html.erb</p>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -10,23 +10,26 @@
             <%= form_with model: @order, url: confirm_orders_path, method: :post do |f| %>
                <!--支払い方法-->
 
-                <div class="form-group">
-                    <label>支払い方法</label>
+
+                <label class="font-weight-bold">支払い方法</label>
+                    <div class="form-group">
                         <%= f.radio_button :payment_method, Order.payment_methods.key(0) %>
                         <%= f.label :payment_method, Order.payment_methods_i18n[:credit_card] %>
+                    <div class="form-group">
+                    <div class="form-group">
                         <%= f.radio_button :payment_method, Order.payment_methods.key(1) %>
                         <%= f.label :payment_method, Order.payment_methods_i18n[:transfer]%>
-                </div>
+                    <div class="form-group">
 
                 <!--ご自身の住所-->
-                <div class="form-group">
-                    <label>お届け先</label>
-                    <%= f.radio_button :address_number, 0, checked: true %>
-                    <%= f.label "ご自身の住所" %>
-                    &emsp;&emsp;<%= "#{current_customer.postal_code} #{current_customer.address}" %>
-                    <br>
-                    &emsp;&emsp;<%= "#{current_customer.last_name} #{current_customer.first_name}" %>
-                </div>
+                <label class="font-weight-bold">お届け先</label>
+                    <div class="form-group">
+                        <%= f.radio_button :address_number, 0, checked: true %>
+                        <%= f.label "ご自身の住所" %>
+                        &emsp;&emsp;<%= "#{current_customer.postal_code} #{current_customer.address}" %>
+                        <br>
+                        &emsp;&emsp;<%= "#{current_customer.last_name} #{current_customer.first_name}" %>
+                    </div>
 
 
                 <!--登録先住所から選択-->

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -16,9 +16,9 @@
         				<%= f.text_field :name %>
         		    </div>
 			<%= f.submit "登録する", class: "btn btn-success submit" %>
-                
+
             <% end %>
-            
+
             <table>
                 <thead>
                     <tr>
@@ -28,15 +28,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                       <% @shipping_addresses.each do |shipping_address|%>
-                        <td><%= shipping_address.postal_code %></td>
-                        <td><%= shipping_address.address %></td>
-                        <td><%= shipping_address.name %></td>
-                        <td><%= link_to "編集", edit_shipping_address_path(shipping_address.id), class: "btn btn-success" %></td>
-                        <td><%= link_to "削除", shipping_address_path(shipping_address.id),  class: "btn btn-danger", method: :delete %></td>
-                       <% end %>
-                   </tr>
+                    <% @shipping_addresses.each do |shipping_address|%>
+                        <tr>
+                            <td><%= shipping_address.postal_code %></td>
+                            <td><%= shipping_address.address %></td>
+                            <td><%= shipping_address.name %></td>
+                            <td><%= link_to "編集", edit_shipping_address_path(shipping_address.id), class: "btn btn-success" %></td>
+                            <td><%= link_to "削除", shipping_address_path(shipping_address.id),  class: "btn btn-danger", method: :delete %></td>
+                        </tr>
+                   <% end %>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
1. 管理者のサインイン後の遷移先を注文履歴一覧に変更
2. 商品一覧画面から商品詳細画面に飛べるようにリンクの設定
3. カートが空の時に表示させる内容を変更させるためにviewを修正
4. 注文した際に、自分自身の住所以外だと郵便番号しか保存されないエラーを修正
5. 注文履歴や注文詳細で、姓名が逆の表示になっていたのでコントローラで修正
6. 会員情報編集でメールアドレスのカラムがコントローラになかったので追記

- 登録配送先が２つ以上になるとうまく表示されていなかったので修正
- 注文履歴が多くなって見づらかったので、一度新しい順に並ぶようにコントローラの記述変更

多いですが、確認よろしくお願いいたします。